### PR TITLE
refactor: remove Shield unneeded filters from `$aliases`

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -21,14 +21,6 @@ class Filters extends BaseConfig
         "honeypot" => Honeypot::class,
         "invalidchars" => InvalidChars::class,
         "secureheaders" => SecureHeaders::class,
-        "session" => \CodeIgniter\Shield\Filters\SessionAuth::class,
-        "tokens" => \CodeIgniter\Shield\Filters\TokenAuth::class,
-        "chain" => \CodeIgniter\Shield\Filters\ChainAuth::class,
-        "auth-rates" => \CodeIgniter\Shield\Filters\AuthRates::class,
-        "group" => \CodeIgniter\Shield\Filters\GroupFilter::class,
-        "permission" => \CodeIgniter\Shield\Filters\PermissionFilter::class,
-        "force-reset" =>
-            \CodeIgniter\Shield\Filters\ForcePasswordResetFilter::class,
     ];
 
     /**


### PR DESCRIPTION
These filters are already loaded for you by the registrar class located at src/Config/Registrar.php